### PR TITLE
Add runtime simulation loop and live UI runtime (force vs time)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,6 +4,7 @@ import { SequencePanel } from './components/SequencePanel'
 import { TopBar } from './components/TopBar'
 import { RunStoreProvider, useRunStore } from './store/runStore'
 import { SequenceStoreProvider } from './store/sequenceStore'
+import { SimulationStoreProvider } from './store/simulationStore'
 
 function MainLayout() {
   const { runState } = useRunStore()
@@ -32,7 +33,9 @@ function App() {
   return (
     <RunStoreProvider>
       <SequenceStoreProvider>
-        <MainLayout />
+        <SimulationStoreProvider>
+          <MainLayout />
+        </SimulationStoreProvider>
       </SequenceStoreProvider>
     </RunStoreProvider>
   )

--- a/src/components/CenterPanel.tsx
+++ b/src/components/CenterPanel.tsx
@@ -1,14 +1,50 @@
+import { useMemo } from 'react'
+import { useSimulationStore } from '../store/simulationStore'
+import { formatDuration } from '../utils/format'
+
 const validationMessages = [
   { level: 'Warning', message: 'Calibration offset exceeds target tolerance.' },
   { level: 'Info', message: 'Runtime preview synced with live sensor feed.' },
   { level: 'Warning', message: 'Sequence step 12 missing temperature guard.' },
 ]
 
+const TICK_RATE_LABEL = '25 Hz'
+
 type CenterPanelProps = {
   readOnly: boolean
 }
 
 export function CenterPanel({ readOnly }: CenterPanelProps) {
+  const { samples, time, force, displacement, activeStepId, stepElapsed, totalSteps } = useSimulationStore()
+
+  const chart = useMemo(() => {
+    if (samples.length === 0) {
+      return null
+    }
+
+    const width = 640
+    const height = 180
+    const padding = 18
+    const times = samples.map((sample) => sample.time)
+    const forces = samples.map((sample) => sample.force)
+    const minTime = Math.min(...times)
+    const maxTime = Math.max(...times)
+    const minForce = Math.min(...forces, 0)
+    const maxForce = Math.max(...forces, 1)
+
+    const rangeTime = maxTime - minTime || 1
+    const rangeForce = maxForce - minForce || 1
+
+    const toX = (value: number) =>
+      padding + ((value - minTime) / rangeTime) * (width - padding * 2)
+    const toY = (value: number) =>
+      height - padding - ((value - minForce) / rangeForce) * (height - padding * 2)
+
+    const points = samples.map((sample) => `${toX(sample.time)},${toY(sample.force)}`).join(' ')
+
+    return { width, height, padding, points, minForce, maxForce }
+  }, [samples])
+
   return (
     <section
       className={`flex h-full flex-col gap-4 rounded-xl border border-slate-800 bg-slate-900/30 p-4 ${
@@ -26,10 +62,78 @@ export function CenterPanel({ readOnly }: CenterPanelProps) {
         </span>
       </header>
 
+      <div className="grid gap-4 lg:grid-cols-3">
+        <div className="rounded-lg border border-slate-800 bg-slate-950/60 p-3">
+          <p className="text-[11px] uppercase tracking-[0.2em] text-slate-500">Elapsed time</p>
+          <p className="mt-2 text-lg font-semibold text-slate-100">{formatDuration(time)}</p>
+          <p className="text-xs text-slate-500">Step timer {formatDuration(stepElapsed)}</p>
+        </div>
+        <div className="rounded-lg border border-slate-800 bg-slate-950/60 p-3">
+          <p className="text-[11px] uppercase tracking-[0.2em] text-slate-500">Force</p>
+          <p className="mt-2 text-lg font-semibold text-slate-100">{force.toFixed(2)} kN</p>
+          <p className="text-xs text-slate-500">Target feedback</p>
+        </div>
+        <div className="rounded-lg border border-slate-800 bg-slate-950/60 p-3">
+          <p className="text-[11px] uppercase tracking-[0.2em] text-slate-500">Displacement</p>
+          <p className="mt-2 text-lg font-semibold text-slate-100">{displacement.toFixed(2)} mm</p>
+          <p className="text-xs text-slate-500">
+            {activeStepId ? `Active step ${activeStepId}` : totalSteps === 0 ? 'No steps loaded' : 'Idle'}
+          </p>
+        </div>
+      </div>
+
       <div className="flex flex-1 flex-col gap-4">
-        <div className="flex h-56 flex-col items-center justify-center rounded-lg border border-dashed border-slate-700 bg-slate-950/40 text-sm text-slate-400">
-          <p>Runtime preview placeholder</p>
-          <p className="text-xs text-slate-500">No camera stream connected</p>
+        <div className="rounded-lg border border-slate-800 bg-slate-950/60 p-4">
+          <div className="flex items-center justify-between">
+            <div>
+              <h3 className="text-xs font-semibold uppercase tracking-[0.2em] text-slate-400">
+                Force vs time
+              </h3>
+              <p className="text-xs text-slate-500">Streaming at {TICK_RATE_LABEL}</p>
+            </div>
+            <span className="text-[11px] uppercase tracking-[0.2em] text-slate-500">
+              {samples.length} points
+            </span>
+          </div>
+          <div className="mt-4 flex h-48 items-center justify-center rounded-lg border border-dashed border-slate-800 bg-slate-950/40">
+            {chart ? (
+              <svg viewBox={`0 0 ${chart.width} ${chart.height}`} className="h-full w-full">
+                <defs>
+                  <linearGradient id="forceLine" x1="0" x2="1" y1="0" y2="0">
+                    <stop offset="0%" stopColor="#38bdf8" />
+                    <stop offset="100%" stopColor="#6366f1" />
+                  </linearGradient>
+                </defs>
+                <rect
+                  x={chart.padding}
+                  y={chart.padding}
+                  width={chart.width - chart.padding * 2}
+                  height={chart.height - chart.padding * 2}
+                  fill="none"
+                  stroke="rgba(148,163,184,0.2)"
+                  strokeDasharray="4 6"
+                />
+                <polyline
+                  fill="none"
+                  stroke="url(#forceLine)"
+                  strokeWidth="2"
+                  strokeLinejoin="round"
+                  points={chart.points}
+                />
+              </svg>
+            ) : (
+              <div className="text-center text-xs text-slate-500">
+                <p>No runtime data yet.</p>
+                <p>Press Start to begin streaming.</p>
+              </div>
+            )}
+          </div>
+          {chart && (
+            <div className="mt-3 flex items-center justify-between text-xs text-slate-500">
+              <span>Min {chart.minForce.toFixed(2)} kN</span>
+              <span>Max {chart.maxForce.toFixed(2)} kN</span>
+            </div>
+          )}
         </div>
 
         <div className="rounded-lg border border-slate-800 bg-slate-950/60 p-4">

--- a/src/components/SequencePanel.tsx
+++ b/src/components/SequencePanel.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react'
 import { StepList } from './sequence/StepList'
 import { useSequenceStore } from '../store/sequenceStore'
+import { useSimulationStore } from '../store/simulationStore'
 import type { StepType } from '../types/sequence'
 
 type SequencePanelProps = {
@@ -10,6 +11,7 @@ type SequencePanelProps = {
 export function SequencePanel({ readOnly }: SequencePanelProps) {
   const { steps, selectedStepId, addStep, duplicateStep, deleteStep, selectStep, toggleStepEnabled, reorderSteps } =
     useSequenceStore()
+  const { activeStepId } = useSimulationStore()
   const [isAddMenuOpen, setIsAddMenuOpen] = useState(false)
   const selectedStep = steps.find((step) => step.id === selectedStepId) ?? null
 
@@ -119,6 +121,7 @@ export function SequencePanel({ readOnly }: SequencePanelProps) {
       <StepList
         steps={steps}
         selectedStepId={selectedStepId}
+        activeStepId={activeStepId}
         isDragDisabled={!canEdit}
         onSelect={selectStep}
         onReorder={reorderSteps}

--- a/src/components/TopBar.tsx
+++ b/src/components/TopBar.tsx
@@ -1,5 +1,7 @@
 import { useRunStore } from '../store/runStore'
 import { useSequenceStore } from '../store/sequenceStore'
+import { useSimulationStore } from '../store/simulationStore'
+import { formatDuration } from '../utils/format'
 
 const statusStyles: Record<string, string> = {
   READY: 'bg-emerald-500/20 text-emerald-200 border-emerald-400/40',
@@ -10,8 +12,9 @@ const statusStyles: Record<string, string> = {
 }
 
 export function TopBar() {
-  const { runState, start, pause, stop, abort } = useRunStore()
+  const { runState, start, pause, resume, stop, abort, reset } = useRunStore()
   const { steps } = useSequenceStore()
+  const { time, activeStepIndex, totalSteps } = useSimulationStore()
   const isReady = runState === 'READY'
   const isRunning = runState === 'RUNNING'
   const isPaused = runState === 'PAUSED'
@@ -19,8 +22,10 @@ export function TopBar() {
 
   const canStart = isReady && errorCount === 0
   const canPause = isRunning
+  const canResume = isPaused
   const canStop = isRunning || isPaused
   const canAbort = isRunning || isPaused
+  const canReset = !isReady
 
   return (
     <header className="flex flex-wrap items-center justify-between gap-4 border-b border-slate-800 bg-slate-950/80 px-6 py-4">
@@ -41,11 +46,13 @@ export function TopBar() {
       <div className="flex flex-wrap items-center gap-6 text-xs text-slate-300">
         <div>
           <p className="text-[11px] uppercase tracking-[0.25em] text-slate-500">Runtime</p>
-          <p className="font-semibold">00:12:18</p>
+          <p className="font-semibold">{formatDuration(time)}</p>
         </div>
         <div>
           <p className="text-[11px] uppercase tracking-[0.25em] text-slate-500">Sequence</p>
-          <p className="font-semibold">Step 05 / 24</p>
+          <p className="font-semibold">
+            {totalSteps === 0 ? 'No steps' : `Step ${activeStepIndex + 1} / ${totalSteps}`}
+          </p>
         </div>
         <div>
           <p className="text-[11px] uppercase tracking-[0.25em] text-slate-500">Validation</p>
@@ -82,6 +89,18 @@ export function TopBar() {
         </button>
         <button
           type="button"
+          onClick={resume}
+          disabled={!canResume}
+          className={`rounded-md px-4 py-2 text-sm font-semibold transition ${
+            canResume
+              ? 'bg-indigo-400/90 text-slate-950 hover:bg-indigo-300'
+              : 'cursor-not-allowed bg-slate-800 text-slate-500'
+          }`}
+        >
+          Resume
+        </button>
+        <button
+          type="button"
           onClick={stop}
           disabled={!canStop}
           className={`rounded-md px-4 py-2 text-sm font-semibold transition ${
@@ -103,6 +122,18 @@ export function TopBar() {
           }`}
         >
           Abort
+        </button>
+        <button
+          type="button"
+          onClick={reset}
+          disabled={!canReset}
+          className={`rounded-md px-4 py-2 text-sm font-semibold transition ${
+            canReset
+              ? 'bg-slate-700 text-slate-100 hover:bg-slate-600'
+              : 'cursor-not-allowed bg-slate-800 text-slate-500'
+          }`}
+        >
+          Reset
         </button>
       </div>
     </header>

--- a/src/components/sequence/StepList.tsx
+++ b/src/components/sequence/StepList.tsx
@@ -14,6 +14,7 @@ import type { SequenceStep } from '../../types/sequence'
 type StepListProps = {
   steps: SequenceStep[]
   selectedStepId: string | null
+  activeStepId: string | null
   isDragDisabled: boolean
   onSelect: (stepId: string) => void
   onReorder: (activeId: string, overId: string) => void
@@ -22,6 +23,7 @@ type StepListProps = {
 export function StepList({
   steps,
   selectedStepId,
+  activeStepId,
   isDragDisabled,
   onSelect,
   onReorder,
@@ -51,6 +53,7 @@ export function StepList({
               key={step.id}
               step={step}
               isSelected={step.id === selectedStepId}
+              isActive={step.id === activeStepId}
               isDragDisabled={isDragDisabled}
               onSelect={onSelect}
             />

--- a/src/components/sequence/StepListItem.tsx
+++ b/src/components/sequence/StepListItem.tsx
@@ -5,11 +5,12 @@ import type { SequenceStep } from '../../types/sequence'
 type StepListItemProps = {
   step: SequenceStep
   isSelected: boolean
+  isActive: boolean
   isDragDisabled: boolean
   onSelect: (stepId: string) => void
 }
 
-export function StepListItem({ step, isSelected, isDragDisabled, onSelect }: StepListItemProps) {
+export function StepListItem({ step, isSelected, isActive, isDragDisabled, onSelect }: StepListItemProps) {
   const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
     id: step.id,
     disabled: isDragDisabled,
@@ -27,7 +28,9 @@ export function StepListItem({ step, isSelected, isDragDisabled, onSelect }: Ste
       className={`flex items-center gap-3 rounded-lg border px-3 py-3 text-left transition ${
         isSelected
           ? 'border-indigo-400/70 bg-indigo-500/10'
-          : 'border-slate-800 bg-slate-950/60'
+          : isActive
+            ? 'border-emerald-400/60 bg-emerald-500/10'
+            : 'border-slate-800 bg-slate-950/60'
       } ${isDragging ? 'opacity-70' : ''}`}
       role="listitem"
     >
@@ -42,6 +45,11 @@ export function StepListItem({ step, isSelected, isDragDisabled, onSelect }: Ste
             <span className="rounded-full border border-slate-700 px-2 py-0.5 text-[10px] uppercase tracking-[0.18em] text-slate-500">
               {step.type}
             </span>
+            {isActive && (
+              <span className="rounded-full border border-emerald-400/70 px-2 py-0.5 text-[10px] uppercase tracking-[0.18em] text-emerald-200">
+                Live
+              </span>
+            )}
             {!step.enabled && (
               <span className="rounded-full border border-slate-700 px-2 py-0.5 text-[10px] uppercase tracking-[0.18em] text-slate-500">
                 Disabled

--- a/src/store/runStore.tsx
+++ b/src/store/runStore.tsx
@@ -6,6 +6,7 @@ type RunStore = {
   runState: RunState
   start: () => void
   pause: () => void
+  resume: () => void
   stop: () => void
   abort: () => void
   reset: () => void
@@ -21,6 +22,7 @@ export function RunStoreProvider({ children }: { children: ReactNode }) {
       runState,
       start: () => setRunState('RUNNING'),
       pause: () => setRunState('PAUSED'),
+      resume: () => setRunState('RUNNING'),
       stop: () => setRunState('STOPPED'),
       abort: () => setRunState('ABORTED'),
       reset: () => setRunState('READY'),

--- a/src/store/simulationStore.tsx
+++ b/src/store/simulationStore.tsx
@@ -1,0 +1,304 @@
+import { createContext, useContext, useEffect, useMemo, useRef, useState, type ReactNode } from 'react'
+import type { EndCriterion, SequenceStep } from '../types/sequence'
+import { useRunStore } from './runStore'
+import { useSequenceStore } from './sequenceStore'
+
+const TICK_RATE_HZ = 25
+const TICK_SECONDS = 1 / TICK_RATE_HZ
+const MAX_SAMPLES = 600
+
+export type RuntimeSample = {
+  time: number
+  force: number
+  displacement: number
+}
+
+type SimulationState = {
+  time: number
+  force: number
+  displacement: number
+  activeStepId: string | null
+  activeStepIndex: number
+  stepElapsed: number
+  totalSteps: number
+  samples: RuntimeSample[]
+}
+
+type SimulationStore = SimulationState
+
+const SimulationStoreContext = createContext<SimulationStore | null>(null)
+
+const initialState: SimulationState = {
+  time: 0,
+  force: 0,
+  displacement: 0,
+  activeStepId: null,
+  activeStepIndex: 0,
+  stepElapsed: 0,
+  totalSteps: 0,
+  samples: [],
+}
+
+type InternalState = {
+  time: number
+  force: number
+  displacement: number
+  stepElapsed: number
+  stepIndex: number
+  cyclesCompleted: number
+  samples: RuntimeSample[]
+  activeStepId: string | null
+}
+
+const getEnabledSteps = (steps: SequenceStep[]) => steps.filter((step) => step.enabled)
+
+const computeStepEnd = (
+  step: SequenceStep,
+  state: InternalState,
+  totalCycles: number | null,
+): boolean => {
+  if (step.type === 'Stop') {
+    return true
+  }
+
+  const enabledCriteria = step.endCriteria.filter((criterion) => criterion.enabled)
+  const hasCriteria = enabledCriteria.length > 0
+
+  const meetsCriterion = (criterion: EndCriterion) => {
+    const value = criterion.value ?? null
+    if (value === null) {
+      return false
+    }
+    switch (criterion.type) {
+      case 'Time':
+        return state.stepElapsed >= value
+      case 'Voltage':
+      case 'Current':
+        return state.force >= value
+      case 'Temperature':
+        return state.displacement >= value
+      case 'Cycles':
+        return state.cyclesCompleted >= value
+      default:
+        return false
+    }
+  }
+
+  if (hasCriteria && enabledCriteria.some((criterion) => meetsCriterion(criterion))) {
+    return true
+  }
+
+  if (!hasCriteria) {
+    if (step.type === 'Hold') {
+      const holdTime = step.parameters.holdTime ?? null
+      return holdTime !== null ? state.stepElapsed >= holdTime : false
+    }
+    if (step.type === 'Cyclic') {
+      return totalCycles !== null ? state.cyclesCompleted >= totalCycles : false
+    }
+    if (step.type === 'Ramp' || step.type === 'Return') {
+      const target = step.parameters.target ?? state.force
+      return Math.abs(state.force - target) < 0.001
+    }
+  }
+
+  return false
+}
+
+export function SimulationStoreProvider({ children }: { children: ReactNode }) {
+  const { runState, stop } = useRunStore()
+  const { steps } = useSequenceStore()
+  const [snapshot, setSnapshot] = useState<SimulationState>(initialState)
+  const intervalRef = useRef<number | null>(null)
+  const prevRunStateRef = useRef(runState)
+  const stepsRef = useRef<SequenceStep[]>(steps)
+  const enabledStepsRef = useRef<SequenceStep[]>(getEnabledSteps(steps))
+
+  const internalStateRef = useRef<InternalState>({
+    time: 0,
+    force: 0,
+    displacement: 0,
+    stepElapsed: 0,
+    stepIndex: 0,
+    cyclesCompleted: 0,
+    samples: [],
+    activeStepId: null,
+  })
+
+  useEffect(() => {
+    stepsRef.current = steps
+    enabledStepsRef.current = getEnabledSteps(steps)
+  }, [steps])
+
+  const commitSnapshot = (state: InternalState) => {
+    setSnapshot({
+      time: state.time,
+      force: state.force,
+      displacement: state.displacement,
+      activeStepId: state.activeStepId,
+      activeStepIndex: state.stepIndex,
+      stepElapsed: state.stepElapsed,
+      totalSteps: enabledStepsRef.current.length,
+      samples: state.samples,
+    })
+  }
+
+  const resetSimulation = () => {
+    const state = internalStateRef.current
+    state.time = 0
+    state.force = 0
+    state.displacement = 0
+    state.stepElapsed = 0
+    state.stepIndex = 0
+    state.cyclesCompleted = 0
+    state.samples = []
+    state.activeStepId = null
+    commitSnapshot(state)
+  }
+
+  const initializeSimulation = () => {
+    const state = internalStateRef.current
+    const enabledSteps = enabledStepsRef.current
+    const firstStep = enabledSteps[0] ?? null
+
+    state.time = 0
+    state.force = 0
+    state.displacement = 0
+    state.stepElapsed = 0
+    state.stepIndex = 0
+    state.cyclesCompleted = 0
+    state.samples = []
+    state.activeStepId = firstStep?.id ?? null
+
+    commitSnapshot(state)
+
+    if (!firstStep) {
+      stop()
+    }
+  }
+
+  const stopInterval = () => {
+    if (intervalRef.current !== null) {
+      window.clearInterval(intervalRef.current)
+      intervalRef.current = null
+    }
+  }
+
+  const startInterval = () => {
+    if (intervalRef.current !== null) {
+      return
+    }
+    intervalRef.current = window.setInterval(() => {
+      const state = internalStateRef.current
+      const enabledSteps = enabledStepsRef.current
+      const step = enabledSteps[state.stepIndex]
+
+      if (!step) {
+        stop()
+        return
+      }
+
+      if (step.type === 'Stop') {
+        stop()
+        return
+      }
+
+      state.time += TICK_SECONDS
+      state.stepElapsed += TICK_SECONDS
+
+      if (step.type === 'Ramp' || step.type === 'Return') {
+        const target = step.parameters.target ?? state.force
+        const rate = step.parameters.rate ?? 1
+        const direction = target >= state.force ? 1 : -1
+        const delta = rate * TICK_SECONDS * direction
+        if (Math.abs(target - state.force) <= Math.abs(delta)) {
+          state.force = target
+        } else {
+          state.force += delta
+        }
+      }
+
+      if (step.type === 'Hold') {
+        const target = step.parameters.target ?? state.force
+        state.force = target
+      }
+
+      if (step.type === 'Cyclic') {
+        const amplitude = step.parameters.target ?? 1
+        const frequency = step.parameters.rate ?? 1
+        const angular = 2 * Math.PI * frequency
+        state.force = amplitude * Math.sin(angular * state.stepElapsed)
+        state.cyclesCompleted = Math.floor(state.stepElapsed * frequency)
+      }
+
+      state.displacement = state.force * 0.12
+
+      const totalCycles = step.parameters.cycles ?? null
+      const isComplete = computeStepEnd(step, state, totalCycles)
+
+      if (isComplete) {
+        const nextIndex = state.stepIndex + 1
+        const nextStep = enabledSteps[nextIndex]
+        if (!nextStep) {
+          stop()
+          return
+        }
+
+        state.stepIndex = nextIndex
+        state.stepElapsed = 0
+        state.cyclesCompleted = 0
+        state.activeStepId = nextStep.id
+
+        if (nextStep.type === 'Stop') {
+          stop()
+          return
+        }
+      }
+
+      const nextSamples = [...state.samples, { time: state.time, force: state.force, displacement: state.displacement }]
+      state.samples = nextSamples.length > MAX_SAMPLES ? nextSamples.slice(-MAX_SAMPLES) : nextSamples
+
+      commitSnapshot(state)
+    }, TICK_SECONDS * 1000)
+  }
+
+  useEffect(() => {
+    const prev = prevRunStateRef.current
+
+    if (runState === 'RUNNING') {
+      if (prev !== 'PAUSED') {
+        initializeSimulation()
+      }
+      startInterval()
+    }
+
+    if (runState === 'PAUSED' || runState === 'STOPPED' || runState === 'ABORTED') {
+      stopInterval()
+    }
+
+    if (runState === 'READY') {
+      stopInterval()
+      resetSimulation()
+    }
+
+    prevRunStateRef.current = runState
+  }, [runState])
+
+  useEffect(() => {
+    return () => {
+      stopInterval()
+    }
+  }, [])
+
+  const value = useMemo<SimulationStore>(() => snapshot, [snapshot])
+
+  return <SimulationStoreContext.Provider value={value}>{children}</SimulationStoreContext.Provider>
+}
+
+export function useSimulationStore() {
+  const store = useContext(SimulationStoreContext)
+  if (!store) {
+    throw new Error('useSimulationStore must be used within SimulationStoreProvider')
+  }
+  return store
+}

--- a/src/utils/format.ts
+++ b/src/utils/format.ts
@@ -1,0 +1,9 @@
+export const formatDuration = (totalSeconds: number) => {
+  const clamped = Math.max(0, totalSeconds)
+  const hours = Math.floor(clamped / 3600)
+  const minutes = Math.floor((clamped % 3600) / 60)
+  const seconds = Math.floor(clamped % 60)
+
+  const parts = [hours, minutes, seconds].map((value) => String(value).padStart(2, '0'))
+  return parts.join(':')
+}


### PR DESCRIPTION
### Motivation

- Provide a deterministic, in-memory simulation engine so methods can be “run” end-to-end without hardware or backend.
- Surface live runtime data (time, force, displacement) and active-step status in the UI for a realistic preview of test execution.
- Expose run controls (Start/Pause/Resume/Stop/Abort/Reset) tied to the simulated clock so the app can demonstrate runState interactions.

### Description

- Add a new `SimulationStoreProvider` with a 25 Hz simulation loop that produces `time`, `force`, `displacement`, a bounded `samples` buffer, and deterministic end-criteria/step progression logic (`src/store/simulationStore.tsx`).
- Integrate the simulation provider into the app tree and expose the runtime store via `useSimulationStore`, and add a small `formatDuration` util (`src/App.tsx`, `src/utils/format.ts`).
- Update UI to consume runtime data: `TopBar` shows formatted runtime and current step index and includes `Resume`/`Reset` controls, `CenterPanel` shows readouts and a streaming force-vs-time SVG chart, and `SequencePanel`/`StepListItem` highlight the active step as Live. (`src/components/TopBar.tsx`, `src/components/CenterPanel.tsx`, `src/components/SequencePanel.tsx`, `src/components/sequence/*`).
- Extend `runStore` API with `resume` and wire runState transitions so simulation initializes on `RUNNING`, pauses on `PAUSED`, and resets on `READY` (`src/store/runStore.tsx`).

### Testing

- Ran `npm run build`, which failed due to unresolved frontend dependencies and TypeScript errors related to missing imports (`react-hook-form`, `@dnd-kit/*`) and some validation typing; build did not succeed in this environment.
- Started the dev server with `npm run dev`, where Vite launched but dependency pre-bundling failed with unresolved imports leading to the dev overlay (missing packages prevented a clean runtime).
- Executed an automated browser screenshot script against the running dev server which produced a runtime screenshot artifact showing the new UI, but the page displayed the Vite overlay due to the missing dependencies.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696d21ae084483208b1415f24b3a3f19)